### PR TITLE
Added log4j.properties for Testcontainers output

### DIFF
--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,6 @@
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d %d{Z} [%t] %-5p (%F:%L) - %m%n
+
+log4j.rootLogger=INFO, console


### PR DESCRIPTION
A log4j.properties file has been added to display log output from Testcontainers.